### PR TITLE
Fix admin UI static file mount path.

### DIFF
--- a/admin/app/static.js
+++ b/admin/app/static.js
@@ -42,8 +42,8 @@ var lessOptions = {
 
 /* Configure router */
 
-router.use('/styles', less(__dirname + '../../public/styles', lessOptions));
-router.use(express.static(__dirname + '../../public'));
+router.use('/styles', less(path.join(__dirname, '../public/styles'), lessOptions));
+router.use(express.static(path.join(__dirname, '../public')));
 router.get('/js/fields.js', bundles.fields.serve);
 router.get('/js/home.js', bundles.home.serve);
 router.get('/js/item.js', bundles.item.serve);


### PR DESCRIPTION
Keystone admin panel looks like this after upgrading to node 6

![screen shot 2016-06-22 at 11 31 45](https://cloud.githubusercontent.com/assets/4499581/16263561/f2752aea-386c-11e6-9d67-2d31c69b380e.jpg)

This fix repairs the damage by correctly rendering the paths to `auth.min.css`
